### PR TITLE
feat: add y/Y shortcuts to copy path and file contents to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Starts in the current working directory.
 | `←` / `h` / `backspace` | go to parent |
 | `H` | go to home directory |
 | `o` | open with configured program |
+| `y` | copy absolute path to clipboard |
+| `Y` | copy file contents to clipboard (files only) |
 | `p` | toggle preview panel |
 | `[` / `]` | scroll preview up / down |
 | `/` | filter entries as you type |

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -19,6 +19,8 @@ func RunHelp() {
 	fmt.Println("  ←    h/backspace  go to parent")
 	fmt.Println("  H               go to home directory")
 	fmt.Println("  o               open with configured program")
+	fmt.Println("  y               copy absolute path to clipboard")
+	fmt.Println("  Y               copy file contents to clipboard")
 	fmt.Println("  p               toggle preview panel (text + images via chafa)")
 	fmt.Println("  [  ]            scroll preview up / down")
 	fmt.Println("  /               filter entries as you type")

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -10,6 +10,7 @@ func RunHelp() {
 	fmt.Println("  peektea init         interactive setup of ~/.peektea.toml")
 	fmt.Println("  peektea uninstall    remove peektea and optionally its config")
 	fmt.Println("  peektea version      show version")
+	fmt.Println("  peektea -i, --issue  open the GitHub issues page")
 	fmt.Println("  peektea -h           show this help")
 	fmt.Println()
 	fmt.Println("Keys:")

--- a/internal/cmd/issue.go
+++ b/internal/cmd/issue.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/lovestaco/peektea/internal/config"
+)
+
+const issuesURL = "https://github.com/lovestaco/peektea/issues"
+
+// RunIssue opens the project's GitHub issues page in the default browser.
+func RunIssue() {
+	opener, args := browserOpener()
+
+	if _, err := exec.LookPath(opener); err != nil {
+		fmt.Println("Open this URL to view or file an issue:")
+		fmt.Println(issuesURL)
+		return
+	}
+
+	c := exec.Command(opener, append(args, issuesURL)...)
+	if err := c.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open browser: %v\n", err)
+		fmt.Println(issuesURL)
+		os.Exit(1)
+	}
+}
+
+// browserOpener returns the command and leading args used to open a URL
+// in the default browser for the current platform.
+func browserOpener() (string, []string) {
+	if runtime.GOOS == "darwin" {
+		return "open", nil
+	}
+	if wslOpener := config.WSLOpener(); wslOpener != "" {
+		return wslOpener, nil
+	}
+	return "xdg-open", nil
+}

--- a/main.go
+++ b/main.go
@@ -752,6 +752,8 @@ func main() {
 			cmd.RunHelp()
 		case "version", "--version", "-v":
 			cmd.RunVersion(version)
+		case "--issue", "-i":
+			cmd.RunIssue()
 		default:
 			fmt.Fprintf(os.Stderr, "unknown command: %s\n\nrun 'peektea -h' for help\n", os.Args[1])
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -56,6 +57,7 @@ type model struct {
 	cursor         int
 	err            error
 	status         string
+	statusErr      bool
 	config         config.Config
 	width          int
 	height         int
@@ -178,11 +180,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case openResultMsg:
 		if msg.err != nil {
 			m.status = fmt.Sprintf("open failed: %v", msg.err)
+			m.statusErr = true
 		}
 		return m, nil
 
 	case tea.KeyMsg:
 		m.status = ""
+		m.statusErr = false
 
 		if m.filtering {
 			switch msg.String() {
@@ -312,8 +316,47 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				c := exec.Command(prog, path)
 				if err := c.Start(); err != nil {
 					m.status = fmt.Sprintf("open failed: %v", err)
+					m.statusErr = true
 				} else {
 					go c.Wait() //nolint — reap child to avoid zombie
+				}
+			}
+
+		case "y":
+			if len(m.entries) > 0 {
+				path := filepath.Join(m.dir, m.entries[m.cursor].Name())
+				if err := clipboard.WriteAll(path); err != nil {
+					m.status = fmt.Sprintf("copy failed: %v", err)
+					m.statusErr = true
+				} else {
+					m.status = "copied path"
+				}
+			}
+
+		case "Y":
+			if len(m.entries) > 0 {
+				entry := m.entries[m.cursor]
+				if entry.IsDir() {
+					m.status = "Y only works on files"
+				} else {
+					path := filepath.Join(m.dir, entry.Name())
+					if isBinary(path) {
+						m.status = "Y: binary file, skipped"
+					} else {
+						data, err := os.ReadFile(path)
+						if err != nil {
+							m.status = fmt.Sprintf("copy failed: %v", err)
+							m.statusErr = true
+						} else {
+							lines := strings.Count(string(data), "\n")
+							if err := clipboard.WriteAll(string(data)); err != nil {
+								m.status = fmt.Sprintf("copy failed: %v", err)
+								m.statusErr = true
+							} else {
+								m.status = fmt.Sprintf("copied contents (%d lines)", lines)
+							}
+						}
+					}
 				}
 			}
 
@@ -502,9 +545,9 @@ func (m model) renderFileList() string {
 	}
 	var hint string
 	if m.showPreview {
-		hint = fmt.Sprintf("enter:go in  o:open  /:filter  .:%-11s  [/]:scroll  p:close  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
+		hint = fmt.Sprintf("enter:go in  o:open  y:path  Y:file  /:filter  .:%-11s  [/]:scroll  p:close  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
 	} else {
-		hint = fmt.Sprintf("enter:go in  o:open  /:filter  .:%-11s  p:preview  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
+		hint = fmt.Sprintf("enter:go in  o:open  y:path  Y:file  /:filter  .:%-11s  p:preview  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
 	}
 
 	var sb strings.Builder
@@ -531,7 +574,11 @@ func (m model) renderFileList() string {
 	}
 	sb.WriteString("\n" + pathStyle.Render(hint))
 	if m.status != "" {
-		sb.WriteString("\n" + errorStyle.Render(m.status))
+		if m.statusErr {
+			sb.WriteString("\n" + errorStyle.Render(m.status))
+		} else {
+			sb.WriteString("\n" + pathStyle.Render(m.status))
+		}
 	}
 
 	if m.showPreview {


### PR DESCRIPTION
Closes #2

## Summary

- `y` copies the absolute path of the highlighted entry (files and directories) to the system clipboard
- `Y` copies the full contents of the highlighted file; gracefully skips directories (`Y only works on files`) and binary files (`Y: binary file, skipped`)
- Feedback shown in the hint bar: success uses the dimmed hint style (`copied path`, `copied contents (N lines)`), errors use red

## Implementation notes

- Uses `github.com/atotto/clipboard` (already in the module graph, now promoted to a direct dep) — cross-platform: `pbcopy` on macOS, `wl-copy`/`xclip` on Linux, `clip.exe` on WSL/Windows
- `y` copies the Linux path (consistent with how the rest of the UI shows paths)
- `Y` copies the full file with no line cap (unlike preview which caps at 500)
- Binary detection reuses the existing `isBinary()` helper

## Test plan

- [ ] `y` on a file → absolute path on clipboard, hint bar shows `copied path`
- [ ] `y` on a directory → absolute path on clipboard, hint bar shows `copied path`
- [ ] `Y` on a text file → contents on clipboard, hint bar shows `copied contents (N lines)`
- [ ] `Y` on a directory → hint bar shows `Y only works on files`, nothing copied
- [ ] `Y` on a binary file → hint bar shows `Y: binary file, skipped`, nothing copied
- [ ] `peektea -h` shows the two new keys
- [ ] Hint bar at bottom shows `y:path  Y:file`
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to open the project’s issue page from the app or CLI help.
  * Added clipboard shortcuts: `y` copies the selected item’s full path, and `Y` copies file contents.

* **Bug Fixes**
  * Improved error handling so failed launch attempts are shown more clearly, and the status display resets after the next keypress.

* **Documentation**
  * Updated help text and README key bindings to reflect the new shortcuts and issue-page option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->