### PR TITLE
feat: add cut/paste move (x to cut, v to paste)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ Starts in the current working directory.
 | `←` / `h` / `backspace` | go to parent |
 | `H` | go to home directory |
 | `o` | open with configured program |
+| `x` | cut (stage for move) |
+| `v` | paste (move staged entry into current directory) |
 | `p` | toggle preview panel |
 | `[` / `]` | scroll preview up / down |
 | `/` | filter entries as you type |
-| `esc` | exit filter / clear active filter |
+| `esc` | exit filter / clear active filter / cancel staged move |
 | `.` | toggle hidden files (dotfiles) |
 | `s` | cycle sort: name → size → modified |
 | `q` / `ctrl+c` | quit |

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -19,6 +19,8 @@ func RunHelp() {
 	fmt.Println("  ←    h/backspace  go to parent")
 	fmt.Println("  H               go to home directory")
 	fmt.Println("  o               open with configured program")
+	fmt.Println("  x               cut (stage for move)")
+	fmt.Println("  v               paste (move staged entry here)")
 	fmt.Println("  p               toggle preview panel (text + images via chafa)")
 	fmt.Println("  [  ]            scroll preview up / down")
 	fmt.Println("  /               filter entries as you type")

--- a/main.go
+++ b/main.go
@@ -50,24 +50,27 @@ type openResultMsg struct{ err error }
 type previewMsg struct{ content string }
 
 type model struct {
-	dir            string
-	allEntries     []os.DirEntry
-	entries        []os.DirEntry
-	cursor         int
-	err            error
-	status         string
-	config         config.Config
-	width          int
-	height         int
-	showPreview    bool
-	previewContent string
-	previewLoading bool
-	showHidden     bool
-	filterInput    textinput.Model
-	filtering      bool
-	sortMode       int
-	previewScroll  int
-	listOffset     int
+	dir              string
+	allEntries       []os.DirEntry
+	entries          []os.DirEntry
+	cursor           int
+	err              error
+	status           string
+	config           config.Config
+	width            int
+	height           int
+	showPreview      bool
+	previewContent   string
+	previewLoading   bool
+	showHidden       bool
+	filterInput      textinput.Model
+	filtering        bool
+	sortMode         int
+	previewScroll    int
+	listOffset       int
+	cutEntry         os.DirEntry
+	cutDir           string
+	confirmOverwrite bool
 }
 
 func newModel(dir string) model {
@@ -129,15 +132,22 @@ func (m model) withFilters() model {
 	return m.clampListOffset()
 }
 
+func (m model) bottomRowCount() int {
+	rows := 2
+	if m.filtering || m.filterInput.Value() != "" {
+		rows++
+	}
+	if m.cutEntry != nil || m.confirmOverwrite {
+		rows++
+	}
+	return rows
+}
+
 func (m model) visibleFileCount() int {
 	if m.height == 0 {
 		return 20
 	}
-	bottomRows := 2
-	if m.filtering || m.filterInput.Value() != "" {
-		bottomRows = 3
-	}
-	v := m.height - 4 - bottomRows // 4 header rows (tagline+blank+path+blank)
+	v := m.height - 4 - m.bottomRowCount() // 4 header rows (tagline+blank+path+blank)
 	if v < 1 {
 		v = 1
 	}
@@ -183,6 +193,44 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		m.status = ""
+
+		if m.confirmOverwrite {
+			switch msg.String() {
+			case "y", "Y":
+				src := filepath.Join(m.cutDir, m.cutEntry.Name())
+				dst := filepath.Join(m.dir, m.cutEntry.Name())
+				m.confirmOverwrite = false
+				if err := os.RemoveAll(dst); err != nil {
+					m.status = fmt.Sprintf("overwrite failed: %v", err)
+					break
+				}
+				name := m.cutEntry.Name()
+				if err := moveEntry(src, dst); err != nil {
+					m.status = fmt.Sprintf("move failed: %v", err)
+				} else {
+					m.cutEntry = nil
+					m.cutDir = ""
+					if all, err := os.ReadDir(m.dir); err == nil {
+						m.allEntries = all
+						m = m.withFilters()
+						for i, e := range m.entries {
+							if e.Name() == name {
+								m.cursor = i
+								m = m.clampListOffset()
+								break
+							}
+						}
+					}
+				}
+			case "n", "N":
+				m.confirmOverwrite = false
+			case "esc":
+				m.confirmOverwrite = false
+				m.cutEntry = nil
+				m.cutDir = ""
+			}
+			return m, nil
+		}
 
 		if m.filtering {
 			switch msg.String() {
@@ -331,11 +379,65 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.filterInput.Focus()
 			return m, textinput.Blink
 
+		case "x":
+			if len(m.entries) > 0 {
+				m.cutEntry = m.entries[m.cursor]
+				m.cutDir = m.dir
+				m.confirmOverwrite = false
+			}
+
+		case "v":
+			if m.cutEntry != nil {
+				src := filepath.Join(m.cutDir, m.cutEntry.Name())
+				dst := filepath.Join(m.dir, m.cutEntry.Name())
+				if src == dst {
+					m.status = "already here"
+					m.cutEntry = nil
+					m.cutDir = ""
+					break
+				}
+				if m.cutEntry.IsDir() {
+					sep := string(filepath.Separator)
+					if m.dir == src || strings.HasPrefix(m.dir, src+sep) {
+						m.status = "cannot move a directory into itself"
+						break
+					}
+				}
+				if _, statErr := os.Stat(dst); statErr == nil {
+					m.confirmOverwrite = true
+					break
+				}
+				name := m.cutEntry.Name()
+				if err := moveEntry(src, dst); err != nil {
+					m.status = fmt.Sprintf("move failed: %v", err)
+				} else {
+					m.cutEntry = nil
+					m.cutDir = ""
+					if all, err := os.ReadDir(m.dir); err == nil {
+						m.allEntries = all
+						m = m.withFilters()
+						for i, e := range m.entries {
+							if e.Name() == name {
+								m.cursor = i
+								m = m.clampListOffset()
+								break
+							}
+						}
+					}
+					needPreview = true
+				}
+			}
+
 		case "esc":
 			if m.filterInput.Value() != "" {
 				m.filterInput.SetValue("")
 				m = m.withFilters()
 				needPreview = true
+			}
+			if m.cutEntry != nil {
+				m.cutEntry = nil
+				m.cutDir = ""
+				m.confirmOverwrite = false
 			}
 
 		case ".":
@@ -502,9 +604,9 @@ func (m model) renderFileList() string {
 	}
 	var hint string
 	if m.showPreview {
-		hint = fmt.Sprintf("enter:go in  o:open  /:filter  .:%-11s  [/]:scroll  p:close  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
+		hint = fmt.Sprintf("enter:go in  o:open  x:cut  /:filter  .:%-11s  [/]:scroll  p:close  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
 	} else {
-		hint = fmt.Sprintf("enter:go in  o:open  /:filter  .:%-11s  p:preview  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
+		hint = fmt.Sprintf("enter:go in  o:open  x:cut  /:filter  .:%-11s  p:preview  s:sorted by %s  H:home  q:quit", dotLabel, sortLabels[m.sortMode])
 	}
 
 	var sb strings.Builder
@@ -512,12 +614,7 @@ func (m model) renderFileList() string {
 
 	if m.height > 0 {
 		linesUsed := strings.Count(top.String(), "\n")
-		// Filter bar (when active or set) sits above the hint — takes one extra row.
-		bottomRows := 2
-		if m.filtering || m.filterInput.Value() != "" {
-			bottomRows = 3
-		}
-		padding := m.height - linesUsed - bottomRows
+		padding := m.height - linesUsed - m.bottomRowCount()
 		for i := 0; i < padding; i++ {
 			sb.WriteByte('\n')
 		}
@@ -528,6 +625,12 @@ func (m model) renderFileList() string {
 	} else if m.filterInput.Value() != "" {
 		sb.WriteString("\n" + filterTagStyle.Render("/"+m.filterInput.Value()) +
 			pathStyle.Render("  esc to clear"))
+	}
+	if m.confirmOverwrite {
+		sb.WriteString("\n" + errorStyle.Render(fmt.Sprintf("'%s' exists here — overwrite? (y/n)", m.cutEntry.Name())))
+	} else if m.cutEntry != nil {
+		sb.WriteString("\n" + filterTagStyle.Render(fmt.Sprintf("moving: %s", m.cutEntry.Name())) +
+			pathStyle.Render("  (v to drop here, esc to cancel)"))
 	}
 	sb.WriteString("\n" + pathStyle.Render(hint))
 	if m.status != "" {

--- a/move.go
+++ b/move.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func moveEntry(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else {
+		var le *os.LinkError
+		if errors.As(err, &le) && errors.Is(le.Err, syscall.EXDEV) {
+			return copyThenDelete(src, dst)
+		}
+		return err
+	}
+}
+
+func copyThenDelete(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		if err := copyDir(src, dst); err != nil {
+			os.RemoveAll(dst) //nolint — best-effort cleanup on partial copy
+			return err
+		}
+		return os.RemoveAll(src)
+	}
+	if err := copyFile(src, dst, info.Mode()); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
+func copyDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, info.Mode()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		s := filepath.Join(src, e.Name())
+		d := filepath.Join(dst, e.Name())
+		if e.Type()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(s)
+			if err != nil {
+				return err
+			}
+			if err := os.Symlink(target, d); err != nil {
+				return err
+			}
+		} else if e.IsDir() {
+			if err := copyDir(s, d); err != nil {
+				return err
+			}
+		} else {
+			fi, err := e.Info()
+			if err != nil {
+				return err
+			}
+			if err := copyFile(s, d, fi.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}


### PR DESCRIPTION
## Summary

Implements the cut→navigate→paste flow from issue #3.

- `x` stages the highlighted file or directory for moving; the hint bar shows `moving: <name>  (v to drop here, esc to cancel)`
- `v` moves the staged entry into the current directory, refreshes the listing, and positions the cursor on it
- `esc` cancels a staged move (in addition to its existing filter-clear behaviour)
- Name collisions show an inline prompt (`'<name>' exists here — overwrite? (y/n)`) before clobbering anything
- Same-directory paste is a no-op with a hint
- Moving a directory into itself or a descendant is refused with a clear message
- Cross-filesystem moves (`EXDEV`) fall back to recursive copy + delete
- Permission/IO errors are shown in the hint bar; the source is left untouched

## Changes

- `move.go` (new) — `moveEntry`, `copyThenDelete`, `copyDir`, `copyFile`
- `main.go` — new model fields (`cutEntry`, `cutDir`, `confirmOverwrite`), `bottomRowCount()` helper, key handlers for `x`/`v`, updated `esc`, updated rendering
- `internal/cmd/help.go` — `x` and `v` added to keys list
- `README.md` — `x` and `v` added to keys table; `esc` row updated

## Test plan

- [ ] `x` on a file → hint bar shows `moving: <name>`
- [ ] Navigate to another directory → `v` moves the file there, cursor lands on it
- [ ] `esc` while staged → staged move cancelled
- [ ] `v` in same directory as source → "already here" hint, entry cleared
- [ ] `v` where a file of the same name exists → overwrite prompt; `y` overwrites, `n` keeps staged, `esc` cancels entirely
- [ ] `x` on a directory, navigate into it, press `v` → "cannot move a directory into itself"
- [ ] `x` on a directory, navigate to a subdirectory of it, press `v` → same guard
- [ ] Move across mount points → copy+delete fallback completes correctly
- [ ] Permission-denied move → error in hint bar, source untouched

Closes #3

 